### PR TITLE
Bump version again for react-native-system-notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gcm-android",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oney/react-native-gcm-android.git"


### PR DESCRIPTION
npm shrinkwrap is failing because of the version difference.